### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing GitHub Skills activity that was announced by the principal in the school assembly.

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `app.py`
- Activity details:
  - **Schedule**: Wednesdays, 3:30 PM - 5:00 PM
  - **Description**: Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications
  - **Max Participants**: 25 students
  - **Current Participants**: None (ready for signups)

## Impact
- Students can now find and sign up for the GitHub Skills activity
- Registration closes at the end of this week, so this is time-sensitive
- Helps students with college applications through the GitHub Certifications program

Fixes #6